### PR TITLE
Add AE2 as a dependency since AE2 is required by the mod.

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "${mod_license}"
 
 # This is a URL to e.g. your GitHub or CurseForge issues page.
 # It will appear in any crash reports this mod is directly involved in.
-# issueTrackerURL="https://github.com/invalid/pleasechangeme/issues" #optional
+issueTrackerURL="https://github.com/liansishen/GTMThings/issues"
 # A list of mods - how many allowed here is determined by the individual mod loader
 
 [[mods]]
@@ -33,5 +33,11 @@ Add some machines to GregTech-Modern
         modId = "gtceu"
         mandatory = true
         versionRange = "[${gtceu_version},)"
+        ordering = "AFTER"
+        side = "BOTH"
+    [[dependencies.${mod_id}]]
+        modId = "ae2"
+        mandadtory = true
+        versionRange = "[${ae2_version},)"
         ordering = "AFTER"
         side = "BOTH"


### PR DESCRIPTION
You should either merge this PR or remove the AE2-related code from the mod. I also added the issue tracker on the mods.toml page because I can.